### PR TITLE
Use spec colors and remove styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Alternatively copy paste [dracula.conf](./dracula.conf) directly into
 
 <!-- This theme is maintained by the following person and a bunch of [awesome contributors](https://github.com/dracula/kitty/graphs/contributors). -->
 
-[![Keegan Carruthers-Smith](https://avatars0.githubusercontent.com/u/187831?v=3&s=70)](https://github.com/keegancsmith) |
---- |
-[Keegan Carruthers-Smith](https://github.com/keegancsmith) |
+| [![Keegan Carruthers-Smith](https://avatars0.githubusercontent.com/u/187831?v=3&s=70)](https://github.com/keegancsmith) | [![Daniel Mita](https://avatars0.githubusercontent.com/u/966706?v=3&s=70)](https://github.com/mienaikage) |
+| ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [Keegan Carruthers-Smith](https://github.com/keegancsmith)                                                              | [Daniel Mita](https://github.com/mienaikage)                                                              |
 
 ## License
 

--- a/dracula.conf
+++ b/dracula.conf
@@ -11,43 +11,43 @@
 foreground            #f8f8f2
 background            #282a36
 selection_foreground  #44475a
-selection_background  #bfbfbf
+selection_background  #f8f8f2
 
 url_color #ffb86c
 
 # black
-color0  #4d4d4d
-color8  #575757
+color0  #21222c
+color8  #6272a4
 
 # red
 color1  #ff5555
-color9  #ff6e67
+color9  #ff6e6e
 
 # green
 color2  #50fa7b
-color10 #5af78e
+color10 #69ff94
 
 # yellow
 color3  #f1fa8c
-color11 #f4f99d
+color11 #ffffa5
 
 # blue
 color4  #bd93f9
-color12 #caa9fa
+color12 #d6acff
 
 # magenta
 color5  #ff79c6
-color13 #ff92d0
+color13 #ff92df
 
 # cyan
 color6  #8be9fd
-color14 #9aedfe
+color14 #a4ffff
 
 # white
-color7  #bfbfbf
-color15 #f8f8f2
+color7  #f8f8f2
+color15 #ffffff
 
-# Cursor styles
+# Cursor colors
 cursor            #f8f8f2
 cursor_text_color background
 

--- a/dracula.conf
+++ b/dracula.conf
@@ -7,39 +7,52 @@
 #
 # Then reload kitty for the config to take affect.
 # Alternatively copy paste below directly into kitty.conf
-foreground #F8F8F2
-background #282A36
-selection_foreground #282A36
-selection_background #F8F8F2
-color0     #000000
-color8     #4D4D4D
-color1     #FF5555
-color9     #FF6E67
-color2     #50FA7B
-color10    #5AF78E
-color3     #F1FA8C
-color11    #F4F99D
-color4     #BD93F9
-color12    #CAA9FA
-color5     #FF79C6
-color13    #FF92D0
-color6     #8BE9FD
-color14    #9AEDFE
-color7     #BFBFBF
-color15    #E6E6E6
 
-# URL styles
-url_color #BD93F9
-url_style single
+foreground            #f8f8f2
+background            #282a36
+selection_foreground  #44475a
+selection_background  #bfbfbf
+
+url_color #ffb86c
+
+# black
+color0  #4d4d4d
+color8  #575757
+
+# red
+color1  #ff5555
+color9  #ff6e67
+
+# green
+color2  #50fa7b
+color10 #5af78e
+
+# yellow
+color3  #f1fa8c
+color11 #f4f99d
+
+# blue
+color4  #bd93f9
+color12 #caa9fa
+
+# magenta
+color5  #ff79c6
+color13 #ff92d0
+
+# cyan
+color6  #8be9fd
+color14 #9aedfe
+
+# white
+color7  #bfbfbf
+color15 #f8f8f2
 
 # Cursor styles
-cursor #E6E6E6
+cursor            #f8f8f2
+cursor_text_color background
 
-# Tab bar colors and styles
-tab_fade 1
-active_tab_foreground #282A36
-active_tab_background #F8F8F2
-active_tab_font_style bold
-inactive_tab_foreground #F8F8F2
-inactive_tab_background #282A36
-inactive_tab_font_style normal
+# Tab bar colors
+active_tab_foreground   #44475a
+active_tab_background   #f8f8f2
+inactive_tab_foreground #282a36
+inactive_tab_background #6272a4


### PR DESCRIPTION
The colors used are the ones from this specification: https://dsifford.github.io/dracula-spec/

I set the URL color to orange as it was the only dracula color not being used anywhere else, I'm not set on it though so feel free to suggest something else.

I removed the styling as I'm of the opinion that the dracula theme should stick with handling the colors, and the user can adjust their styling separately. Otherwise, you have to either remove them yourself or explicitly define back to defaults.

![Screenshot from 2019-06-20 20-08-04](https://user-images.githubusercontent.com/966706/59875102-ce2e5b00-9397-11e9-9e21-c1cb49e4a5ad.png)
