### PR TITLE
Update highlight diff colors

### DIFF
--- a/diff.conf
+++ b/diff.conf
@@ -5,10 +5,10 @@ title_bg             #282a36
 margin_bg            #6272a4
 margin_fg            #44475a
 removed_bg           #ff5555
-highlight_removed_bg #ff79c6
+highlight_removed_bg #ff5555
 removed_margin_bg    #ff5555
 added_bg             #50fa7b
-highlight_added_bg   #ffb86c
+highlight_added_bg   #50fa7b
 added_margin_bg      #50fa7b
 filler_bg            #44475a
 hunk_margin_bg       #44475a


### PR DESCRIPTION
A small fix for the highlight colors on the bottom right corner of a diff. Now insertions are Dracula green and deletions are Dracula red.

<img width="96" alt="Screenshot 2020-06-24 at 10 43 44" src="https://user-images.githubusercontent.com/149248/85523718-9f307200-b607-11ea-99f6-7df52110fd37.png">
