### PR TITLE
Add kitty marks foreground and background color

### DIFF
--- a/dracula.conf
+++ b/dracula.conf
@@ -56,3 +56,7 @@ active_tab_foreground   #44475a
 active_tab_background   #f8f8f2
 inactive_tab_foreground #282a36
 inactive_tab_background #6272a4
+
+# Marks
+mark1_foreground #282a36
+mark1_background #ff5555


### PR DESCRIPTION
[kitty Marks](https://sw.kovidgoyal.net/kitty/marks.html) can be colorized. It supports up to 3 mark groups but I just added colors for the first one. Furthermore I choose `red` because most of the time (at least for me) you search for errors.

### Before

<img width="87" alt="Screenshot 2020-08-14 at 11 43 51" src="https://user-images.githubusercontent.com/149248/90237231-3fdf2900-de24-11ea-9bd5-3800db19501d.png">

### After

<img width="87" alt="Screenshot 2020-08-14 at 11 45 19" src="https://user-images.githubusercontent.com/149248/90237243-453c7380-de24-11ea-8f60-e3fd3c252766.png">
