### PR TITLE
Changes to bring theme up-to-spec

### DIFF
--- a/dracula.conf
+++ b/dracula.conf
@@ -10,10 +10,10 @@
 
 foreground            #f8f8f2
 background            #282a36
-selection_foreground  #44475a
-selection_background  #f8f8f2
+selection_foreground  #ffffff
+selection_background  #44475a
 
-url_color #ffb86c
+url_color #8be9fd
 
 # black
 color0  #21222c
@@ -52,7 +52,7 @@ cursor            #f8f8f2
 cursor_text_color background
 
 # Tab bar colors
-active_tab_foreground   #44475a
+active_tab_foreground   #282a36
 active_tab_background   #f8f8f2
 inactive_tab_foreground #282a36
 inactive_tab_background #6272a4


### PR DESCRIPTION
- Dracula's `Selection` color is meant as a background, not a foreground color, so `selection_background` has been changed to `Selection`, and `selection_foreground` has been changed to `AnsiBrightWhite` for proper contrast.
- `active_tab_foreground` has also been changed from `Selection` to `Background` (for the same reason as the above point). Now an active tab is a simple foreground/background invert, which I think looks really nice.
- URLs should be colored as `Cyan` [per the spec](https://spec.draculatheme.com/#MarkupLinkUrl), so `url_color` has been changed to `Cyan`.