### PR TITLE
Add background color to titlebar on macOS

### DIFF
--- a/dracula.conf
+++ b/dracula.conf
@@ -60,3 +60,6 @@ inactive_tab_background #6272a4
 # Marks
 mark1_foreground #282a36
 mark1_background #ff5555
+
+# Window's titlebar on macOS
+macos_titlebar_color #282a36


### PR DESCRIPTION
before:
<img width="692" alt="Captura de pantalla 2021-02-13 a las 10 10 50" src="https://user-images.githubusercontent.com/11975868/107850781-c7adec00-6de3-11eb-8df4-2b60b3e8442a.png">

after:
<img width="692" alt="Captura de pantalla 2021-02-13 a las 10 06 40" src="https://user-images.githubusercontent.com/11975868/107850768-aa791d80-6de3-11eb-9a27-e2377998561c.png">
