### PR TITLE
Make splits/window border color consistent with other ports

### DIFF
--- a/dracula.conf
+++ b/dracula.conf
@@ -60,3 +60,7 @@ inactive_tab_background #6272a4
 # Marks
 mark1_foreground #282a36
 mark1_background #ff5555
+
+# Splits/Windows
+active_border_color #f8f8f2
+inactive_border_color #6272a4


### PR DESCRIPTION
I don't think is in the Spec, but I see a general usage of gray for the
splits/windows border in other ports such as [Wezterm](https://github.com/dracula/wezterm) and [vim](https://github.com/dracula/vim).
For the active pane I use the same color used for active tabs, for consistenzy
but can be modified.